### PR TITLE
Add justification for numerals in `sz`

### DIFF
--- a/fixed_proj.py
+++ b/fixed_proj.py
@@ -10,7 +10,7 @@ class HadamardProj(nn.Module):
         super(HadamardProj, self).__init__()
         self.output_size = output_size
         self.input_size = input_size
-        sz = 2 ** int(math.ceil(math.log(max(input_size, output_size), 2)))
+        sz = 2 ** int(math.ceil(math.log(max(input_size, output_size), 2)))  # since size needs to be a multiple of 4
         mat = torch.from_numpy(hadamard(sz))
         if fixed_weights:
             self.proj = Variable(mat, requires_grad=False)


### PR DESCRIPTION
Hello @eladhoffer ,

As mentioned in the paper, `sz` needs to be a multiple of 4, which doesn't necessarily strike at first when we look at the equation. So I thought, adding the comment could be a bit useful.

Thank you for the implementation btw.

- Gaurav.